### PR TITLE
Added ability to change zoom on settings screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 dist/
 
 .DS_Store
+.vscode/

--- a/src/main.js
+++ b/src/main.js
@@ -76,7 +76,7 @@ ipcMain.on('pref-change', (e, theme) => {
 });
 
 ipcMain.on('pref-change-zoom', (e, zoom) => {
-    themeInjector.injectZoom(zoom);
+    setZoom(zoom);
     const prefs = store.get('prefs') || {};
     prefs.zoom = zoom;
     store.set('prefs', prefs);
@@ -121,7 +121,7 @@ function createWindow() {
         themeInjector = new ThemeInjector(app, win);
         themeInjector.inject(theme);
         const zoom = store.get('prefs.zoom')  || 100;
-        themeInjector.injectZoom(zoom); 
+        setZoom(zoom); 
         (new MenuInjector(app, win)).inject();
     });
 
@@ -249,4 +249,24 @@ function saveWindowSize() {
     prefs.windowHeight = bounds.height;
 
     store.set('prefs', prefs);
+}
+
+function setZoom(zoom) {
+    try {
+        if (win) {
+            //some reasonable settings (Chrome does the same)
+            if (zoom >= 500)
+            {
+                zoom = 500; //big but not "that" big    
+            }
+            if (zoom > 25 && zoom <= 500) {
+                win.webContents.setZoomFactor(zoom / 100);
+            }
+        }
+    }
+    catch (e)
+    {
+        console.log(e);
+        console.error(`Could not set zoom to ${zoom}`);
+    }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -75,6 +75,13 @@ ipcMain.on('pref-change', (e, theme) => {
     store.set('prefs', prefs);
 });
 
+ipcMain.on('pref-change-zoom', (e, zoom) => {
+    themeInjector.injectZoom(zoom);
+    const prefs = store.get('prefs') || {};
+    prefs.zoom = zoom;
+    store.set('prefs', prefs);
+});
+
 // Show window when clicking on macosx dock icon
 app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -113,6 +120,8 @@ function createWindow() {
         const theme = store.get('prefs.theme')  || 'default';
         themeInjector = new ThemeInjector(app, win);
         themeInjector.inject(theme);
+        const zoom = store.get('prefs.zoom')  || 100;
+        themeInjector.injectZoom(zoom); 
         (new MenuInjector(app, win)).inject();
     });
 

--- a/src/pages/customize.html
+++ b/src/pages/customize.html
@@ -23,6 +23,10 @@
                         <option value="cerulean">Cerulean</option>
                     </select>
                   </div>
+                  <div class="form-group">
+                    <label for="zoom">Zoom (%)</label>
+                    <input class="form-control" id="zoom" value="100" />
+                  </div>
             </div>
         </div>
         <script src="customize.js" type="text/javascript"></script>

--- a/src/pages/customize.js
+++ b/src/pages/customize.js
@@ -16,7 +16,7 @@
     
     const currentZoom = prefs.zoom || 100;
     const zoomSetting = document.getElementById("zoom");
-    zoomSetting.addEventListener('keyup', (e) => {
+    zoomSetting.addEventListener('blur', (e) => {
          const zoom = e.target.value;
          ipcRenderer.send('pref-change-zoom', zoom);
     });

--- a/src/pages/customize.js
+++ b/src/pages/customize.js
@@ -1,7 +1,7 @@
 
 (function() {
     const { ipcRenderer, remote } = require('electron');
-
+    
     console.log(remote);
     const currentWindow = remote.getCurrentWindow();
     const prefs = currentWindow.prefs || {};
@@ -12,6 +12,14 @@
         const theme = e.target.value;
         ipcRenderer.send('pref-change', theme);
     });
-
     themePicker.value = currentTheme;
+    
+    const currentZoom = prefs.zoom || 100;
+    const zoomSetting = document.getElementById("zoom");
+    zoomSetting.addEventListener('keyup', (e) => {
+         const zoom = e.target.value;
+         ipcRenderer.send('pref-change-zoom', zoom);
+    });
+    zoomSetting.value = currentZoom;
+        
 })();

--- a/src/utils/themeInjector.js
+++ b/src/utils/themeInjector.js
@@ -51,7 +51,7 @@ module.exports = class Injector {
         catch (e)
         {
             console.log(e);
-            console.error(`Could not set zoom toe ${zoom}`);
+            console.error(`Could not set zoom to ${zoom}`);
         }
     }
 }

--- a/src/utils/themeInjector.js
+++ b/src/utils/themeInjector.js
@@ -34,26 +34,6 @@ module.exports = class Injector {
             }
         }
     }
-
-    injectZoom(zoom) {
-        try {
-            if (this.win) {
-                //some reasonable settings (Chrome does the same)
-                if (zoom >= 500)
-                {
-                    zoom = 500; //big but not "that" big    
-                }
-                if (zoom > 25 && zoom <= 500) {
-                    this.win.webContents.setZoomFactor(zoom / 100);
-                }
-            }
-        }
-        catch (e)
-        {
-            console.log(e);
-            console.error(`Could not set zoom to ${zoom}`);
-        }
-    }
 }
 
 /**

--- a/src/utils/themeInjector.js
+++ b/src/utils/themeInjector.js
@@ -34,6 +34,26 @@ module.exports = class Injector {
             }
         }
     }
+
+    injectZoom(zoom) {
+        try {
+            if (this.win) {
+                //some reasonable settings (Chrome does the same)
+                if (zoom >= 500)
+                {
+                    zoom = 500; //big but not "that" big    
+                }
+                if (zoom > 25 && zoom <= 500) {
+                    this.win.webContents.setZoomFactor(zoom / 100);
+                }
+            }
+        }
+        catch (e)
+        {
+            console.log(e);
+            console.error(`Could not set zoom toe ${zoom}`);
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Someone asked about making the screen smaller on Discord and started finding out more about how Zoom works on Electron. 

I came up with the new Zoom setting and this is something that I started using right away as the default is a bit smaller for the laptop I'm using. There would definitely be more elegant ways of doing it but this approach was clean enough to warrant a pull request as the outcome is better than what we have (which is always 100% Zoom). 

Only questionable decision is to update the "themeInjector" with "injectZoom" but having a "zoomInjector" file seemed weird considering that "themeInjector" was originally defined as the "Injector" class. Can make changes as needed though.